### PR TITLE
capitalize programming language name in bibtex

### DIFF
--- a/paper/paper.bib
+++ b/paper/paper.bib
@@ -12,7 +12,7 @@ doi = {10.1137/141000671},
 @article{christ2023plots,
   doi = {10.5334/jors.431},
   author = {Christ, Simon and Schwabeneder, Daniel and Rackauckas, Christopher and Borregaard, Michael Krabbe and Breloff, Thomas},
-  title = {Plots.jl - a user extendable plotting API for the julia programming language},
+  title = {Plots.jl - {A} user extendable plotting API for the {J}ulia programming language},
   publisher = {Journal of Open Research Software},
   year = {2023}
 }


### PR DESCRIPTION
Due to the JOSS submission:

https://github.com/openjournals/joss-reviews/issues/8850

